### PR TITLE
Fix unspecified behaviour in linear and stack allocators

### DIFF
--- a/include/ktl/allocators/linear_allocator.h
+++ b/include/ktl/allocators/linear_allocator.h
@@ -127,7 +127,13 @@ namespace ktl
 		*/
 		bool owns(void* p) const noexcept
 		{
-			return p >= m_Data && p < m_Data + Size;
+			// Comparing pointers to different objects is unspecified
+			// But converting them to integers and comparing them isn't...
+			uintptr_t ptr = reinterpret_cast<uintptr_t>(p);
+			uintptr_t low = reinterpret_cast<uintptr_t>(m_Data);
+			uintptr_t high = low + Size;
+
+			return ptr >= low && ptr < high;
 		}
 #pragma endregion
 

--- a/include/ktl/allocators/stack_allocator.h
+++ b/include/ktl/allocators/stack_allocator.h
@@ -98,7 +98,13 @@ namespace ktl
 
 		bool owns(void* p) const noexcept
 		{
-			return p >= m_Block->Data && p < m_Block->Data + Size;
+			// Comparing pointers to different objects is unspecified
+			// But converting them to integers and comparing them isn't...
+			uintptr_t ptr = reinterpret_cast<uintptr_t>(p);
+			uintptr_t low = reinterpret_cast<uintptr_t>(m_Block->Data);
+			uintptr_t high = low + Size;
+
+			return ptr >= low && ptr < high;
 		}
 #pragma endregion
 

--- a/include/ktl/containers/trivial_vector.h
+++ b/include/ktl/containers/trivial_vector.h
@@ -338,7 +338,7 @@ namespace ktl
 		{
 			const size_t n = (last - first);
 
-			if (m_EndMax - m_End < n)
+			if (size_t(m_EndMax - m_End) < n)
 				expand(n);
 
 			T* lastElement = m_End;

--- a/src/test/exotic_allocator_test.cpp
+++ b/src/test/exotic_allocator_test.cpp
@@ -25,9 +25,9 @@ namespace ktl::test::exotic_allocator
     {
         // TODO: More tests with exotic allocator arrangements
         stack<1024> block;
-        type_segragator_allocator<double, 32, stack_allocator<1024>, cascading<linear_allocator<1024>>> alloc(block);
+        segragator<32, stack_allocator<1024>, cascading<linear_allocator<1024>>> alloc(block);
 
-        type_segragator_allocator<double, 32, stack_allocator<1024>, cascading<linear_allocator<1024>>> alloc2(std::move(alloc));
+        segragator<32, stack_allocator<1024>, cascading<linear_allocator<1024>>> alloc2(std::move(alloc));
     }
 
     KTL_ADD_TEST(test_exotic_allocator_1)


### PR DESCRIPTION
Remove move constructors in type_allocator due to STL compliance
Fix warning in trivial_vector